### PR TITLE
fixed import bug for g2p

### DIFF
--- a/g2p_en/__init__.py
+++ b/g2p_en/__init__.py
@@ -1,1 +1,1 @@
-from g2p import  g2p, Session
+from g2p import g2p, Session


### PR DESCRIPTION
The extra space was causing the import to fail.

Found by @benfoley.