### PR TITLE
Partially Fixed - Bug: Throws NumOutOfRangeError for numbers longer than 36 digits #20

### DIFF
--- a/g2p_en/g2p.py
+++ b/g2p_en/g2p.py
@@ -146,6 +146,15 @@ class G2p(object):
         return preds
 
     def __call__(self, text):
+      
+        if text.isnumeric() and len(text) > 36:
+            #for very bigs number
+            #just read the digits
+            prons = []
+            for i in range(len(text)):
+                prons += (self.__call__(text[i]))
+            return prons
+        
         # preprocessing
         text = unicode(text)
         text = normalize_numbers(text)


### PR DESCRIPTION
Now for numbers bigger than 36 digits, g2 will break and call g2p digit wise. This is not the ultimate solution but is somewhat parallel to how humans pronounce very big numbers.

Fixed issue - #20 