### PR TITLE
add load_custom_phonemes()

### DIFF
--- a/g2p_en/g2p.py
+++ b/g2p_en/g2p.py
@@ -71,6 +71,25 @@ class G2p(object):
         self.load_variables()
         self.homograph2features = construct_homograph_dictionary()
 
+    def load_custom_phonemes(self, file_path):
+        '''Load custom graphemes (spelling) to phonemes (pronunciation)
+        in the file, which has the same format with nltk's cmudict:
+            A 1 AH0
+            A. 1 EY1
+            A 2 EY1
+            A42128 1 EY1 F AO1 R T UW1 W AH1 N T UW1 EY1 T
+            AAA 1 T R IH2 P AH0 L EY1
+        '''
+        with open(file_path) as fin:
+            for line in fin:
+                if line[0] == '#':
+                    continue
+                word, left = line.strip().split(' ', maxsplit=1)
+                phonemes = left.split()[1:]
+                word = word.lower()
+                # just replace if word is in cmudict
+                self.cmu[word] = [phonemes]
+
     def load_variables(self):
         self.variables = np.load(os.path.join(dirname,'checkpoint20.npz'))
         self.enc_emb = self.variables["enc_emb"]  # (29, 64). (len(graphemes), emb)


### PR DESCRIPTION
For many technical terms, e.g. "AI", "GitHub", phonemes converted by seq2se2 are not the right pronunciation, so a custom dict is necessary.

The added method `load_custom_phonemes(self, file_path)` to G2p, reads a cmudict like file to self.cmu. usage:
```
from g2p_en import G2p

texts = [
        "AI is popular on GitHub.",
        ]
g2p = G2p()
for text in texts:
    out = g2p(text)
    print(out)

g2p.load_custom_phonemes('./z-custom')
for text in texts:
    out = g2p(text)
    print(out)

['AY1', ' ', 'IH1', 'Z', ' ', 'P', 'AA1', 'P', 'Y', 'AH0', 'L', 'ER0', ' ', 'AA1', 'N', ' ', 'G', 'IH1', 'TH', 'AH0', 'B', ' ', '.']
['EY1', 'AY1', ' ', 'IH1', 'Z', ' ', 'P', 'AA1', 'P', 'Y', 'AH0', 'L', 'ER0', ' ', 'AA1', 'N', ' ', 'G', 'IH0', 'T', 'HH', 'AH1', 'B', ' ', '.']
```